### PR TITLE
changed legend titles better labels 'report types and 'map layers'

### DIFF
--- a/src/flavors/happytrail/jstemplates/pages/achievements.html
+++ b/src/flavors/happytrail/jstemplates/pages/achievements.html
@@ -1,28 +1,18 @@
 <h1>Together, we:</h1>
-
-<h3>Did this many</h3>
-
-ipsem Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-<h3>Did that many</h3>
-
-ipsem Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-<h3>Did this other great thing</h3>
-
-ipem Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+<h3>Transformed the space</h3>
+<ul>
+<li>Removed 200 cubic yards of debris and invasive plants.</li>
+<li>Planted over 200 native plants.</li>
+<li>Replaced 100 cubic yards of topsoil and 50 cubic yards of mulch.</li>
+<li>Laid 92 burlap bags</li>
+<li>Hauled out 4 1/2 giant dump truck loads of waste to the city transfer station.</li>
+</ul>
+<h3>Built connections to our neighborhood</h3>
+<ul>
+<li>
+The beautiful new yarn flowers on the fence were made possible by 15 Latina senior women in South Park who partnered with us and spent 100+ hours crocheting and knitting.
+</li>
+<li>
+We unearthed a historical treasure that had been buried and forgotten. An old brick sidewalk that once connected the old neighborhoods together, in an area used to known as "Catholic Hill." Things changed in 1967, when the freeway was constructed and divided the neighborhoods.
+</li>
+</ul>

--- a/src/flavors/happytrail/jstemplates/pages/scarytrail.html
+++ b/src/flavors/happytrail/jstemplates/pages/scarytrail.html
@@ -2,7 +2,8 @@
 
 <iframe src="https://player.vimeo.com/video/134796456?color=c9ff23&title=0&byline=0&portrait=0" width="520" height="337" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
-<p><strong>The youth of South Park hit the trail with a major overhaul.</strong></p>
-
-
-<p>ipsem Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo</p>
+<strong>The youth of South Park hit the trail with a major overhaul.</strong>
+Watch the video above for a rundown.
+<br>
+<br>
+<h5><a href="/page/achievements">Here's a list of stats on the work that we did</a></h5>

--- a/src/sa_web/static/js/views/legend-view.js
+++ b/src/sa_web/static/js/views/legend-view.js
@@ -21,7 +21,7 @@ var Shareabouts = Shareabouts || {};
     },
 
     renderInfoLayers: function () {
-      var $markup = '<p>Toggle layers:</p><ul class="layer-type-list unstyled-list">',
+      var $markup = '<p>Map layers:</p><ul class="layer-type-list unstyled-list">',
         i, checked, layer;
       var legendLayerId = 0;
 
@@ -46,7 +46,7 @@ var Shareabouts = Shareabouts || {};
     },
 
     renderShareaboutsLayers: function () {
-      var $shareMarkup = '<p>Filter reports:</p><ul class="master-layer-list unstyled-list">',
+      var $shareMarkup = '<p>Report Types:</p><ul class="master-layer-list unstyled-list">',
         i, layer;
 
       for (i = 0; i < this.options.layers.length; i++) {


### PR DESCRIPTION
I've confirmed watching first time users on multiple occasions that the titles "Filter Reports" and "Toggle layers" are confusing. One person from DRCC thought that "Filter Reports" was a noun and not a verb.

I think the labels "Report Types" and "Map Layers" are more clear, as they better describe the things underneath them.