### PR TITLE
Add new class to reduce new form spacing

### DIFF
--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -2,7 +2,7 @@
         <p class="drag-marker-instructions">{{#_}}First drag the map to set your pin's location.{{/_}}</p>
         <p class="drag-marker-warning is-visuallyhidden">{{#_}}It looks like you didn't set your location yet. Please drag the map to your location.{{/_}}</p>
 
-        <p>{{ place_config.help_text }}</p>
+        <p class="form-field">{{ place_config.help_text }}</p>
 
         <form id="place-form" class="place-form clearfix">
 
@@ -93,7 +93,7 @@
               {{/if}}
             </div>
             <!-- TODO Use custom whitespace via CSS instead of p tags -->
-            <p></p>
+            <div class="form-field"></div>
             {{/ place_config.items }}
           </fieldset>
 

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -259,6 +259,10 @@ textarea {
   padding: 1em;
 }
 
+.form-field {
+  margin: 0 0 .25em;
+}
+
 /* Images */
 img {
   max-width: 100%;
@@ -599,7 +603,7 @@ a.logout-btn {
   font-weight: bold;
   text-shadow: -1px 1px 0 rgba(255,255,255,0.5);
   text-align: center;
-  margin-bottom: 1em;
+  margin-bottom: 0.5em;
   padding: 0.75em 1em 0.875em;
   border-radius: 0.325em;
 }


### PR DESCRIPTION
I replaced the `<p>` tags per issue #160 with divs and a new class .form-field. I also tweaked .drag-marker-* to make the spacing more consistent and applied the .form-field class to `{{ place_config.help_text }}`, also for more consistent spacing.